### PR TITLE
chore: Update template copy, add legal disclaimer

### DIFF
--- a/receipt/plain-text.hbs
+++ b/receipt/plain-text.hbs
@@ -8,20 +8,20 @@ in all the possible combinations --}}
 {{!-- Show transaction subject if there aren't multiple cart items
 AND transaction subject is set --}}
 {{#eq cart.items.length 1}}
-  {{#if cart.items.[0].subject}} 
+{{#if cart.items.[0].subject}}
 - - - - - - - - - - -
 
 Oggetto del pagamento:
 {{cart.items.[0].subject}}
-  {{/if}}
+{{/if}}
 {{/eq}}
 {{!-- End condition --}}
 
 - - - - - - - - - - -
 
-{{!-- Show the following key value pair if user is authenticated  --}}
+{{!-- Show the following key value pair if user is authenticated --}}
 {{#with user.data}}
-Pagato da: {{firstName}} {{lastName}} ({{taxCode}})
+Eseguito da: {{firstName}} {{lastName}} ({{taxCode}})
 {{/with}}
 Indirizzo email: {{user.email}}
 ID transazione (RRN): {{transaction.rrn}}
@@ -36,20 +36,20 @@ Data e ora: {{transaction.timestamp}}
 - - - - - - - - - - -
 
 {{#each cart.items}}
-  {{#with this.debtor}}
+{{#with this.debtor}}
 Debitore: {{fullName}} {{#if taxCode}}({{taxCode}}){{/if}}
-  {{/with}}
+{{/with}}
 Ente creditore: {{this.payee.name}}
 Codice Fiscale ente: {{this.payee.taxCode}}
-  {{#eq this.refNumber.type "codiceAvviso"}}
+{{#eq this.refNumber.type "codiceAvviso"}}
 Codice Avviso: {{this.refNumber.value}}
-  {{/eq}}
-  {{#eq this.refNumber.type "IUV"}}
+{{/eq}}
+{{#eq this.refNumber.type "IUV"}}
 IUV: {{this.refNumber.value}}
-  {{/eq}}
-  {{#not @root.cart.items.length 1}}
+{{/eq}}
+{{#not @root.cart.items.length 1}}
 Oggetto del pagamento: {{this.subject}}
-  {{/not}}
+{{/not}}
 Importo: {{this.amount}}
 
 {{/each}}
@@ -62,22 +62,20 @@ Commissione (applicata da {{transaction.psp.name}}): {{transaction.psp.fee.amoun
 Totale: {{transaction.amount}} €
 {{#if transaction.paymentMethod.extraFee}}
 
-Il totale non include eventuali costi di invio bonifico, se applicati dal gestore della transazione (PSP). Per maggiori informazioni, rivolgiti alla tua banca.
+Il totale non include eventuali costi di invio bonifico, se applicati dal gestore della transazione (PSP). Per maggiori
+informazioni, rivolgiti alla tua banca.
 {{/if}}
-
-- - - - - - - - - - -
-{{#if user.data.taxCode}}
-
-Poiché hai effettuato questo pagamento tramite uno strumento tracciabile, puoi usare questa e-mail come ricevuta per le tue detrazioni o deduzioni fiscali.
 
 - - - - - - - - - - -
 {{/if}}
 
 Serve aiuto?
 
-Contatta il servizio di assistenza all'indirizzo https://pagopa.gov.it/assistenza e comunica il codice transazione: {{transaction.id}}.
+Contatta il servizio di assistenza all'indirizzo https://pagopa.gov.it/assistenza e comunica il codice transazione:
+{{transaction.id}}.
 
-Non rispondere a questa email. Questa casella di posta è utilizzata solo per l’invio della presente mail e, non essendo monitorata, non riceveresti risposta.
+Non rispondere a questa email. Questa casella di posta è utilizzata solo per l’invio della presente mail e, non essendo
+monitorata, non riceveresti risposta.
 
 - - - - - - - - - - -
 

--- a/receipt/success/pdf/template.hbs
+++ b/receipt/success/pdf/template.hbs
@@ -39,7 +39,7 @@
 
               {{#with user.data}}
               <dl class="data-key-value">
-                <dt>Pagato da</dt>
+                <dt>Eseguito da</dt>
                 <dd class="entityGroup">
                   <span class="entityName">{{firstName}} {{lastName}}</span>
                   <span class="entityCode">{{taxCode}}</span>

--- a/receipt/success/pdf/template.hbs
+++ b/receipt/success/pdf/template.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.3">
+<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.4">
 
 <head>
   <title>Il riepilogo del tuo pagamento</title>
@@ -229,13 +229,10 @@
 
       <footer>
 
-
-        {{#if user.data.taxCode}}
         <p>
-          Poich&eacute; hai effettuato questo pagamento tramite uno strumento tracciabile, puoi usare questa ricevuta
-          per le tue detrazioni o deduzioni fiscali.
+          Questa ricevuta attesta il pagamento eseguito. Rivolgiti all’Ente Creditore se hai bisogno della quietanza
+          liberatoria.
         </p>
-        {{/if}}
 
         <div class="company-info">
           <div class="pagopa-company-address">


### PR DESCRIPTION
This PR updates some copy related to the payment receipt.

#### List of Changes
- Change copy text from "_Pagato da:_" to "_Eseguito da:_"
  - The edit applies to both simple text and PDF templates
  - I can't apply the edit to the mail template because the partials haven't been migrated yet
- Add a legal disclaimer to all the PDF receipts
- Bump template version