### PR TITLE
chore: Add `splitAndSpace` helper for the `Codice avviso` field

### DIFF
--- a/receipt/success/helpers/splitAndSpace.js
+++ b/receipt/success/helpers/splitAndSpace.js
@@ -1,0 +1,9 @@
+var splitAndSpace = function () {};
+
+splitAndSpace.register = function (Handlebars) {
+  Handlebars.registerHelper("splitAndSpace", function (str) {
+    return str.match(/(.{2,4})/gy).join(" ");
+  });
+};
+
+module.exports = splitAndSpace;

--- a/receipt/success/pdf/package.json
+++ b/receipt/success/pdf/package.json
@@ -4,8 +4,8 @@
   "description": "Template used to generate pagoPA PDF receipts",
   "main": "index.js",
   "scripts": {
-    "generate-complete": "hbs -H ../helpers/eq.js -H ../helpers/not.js --data ../json/authenticated-pdf.json -e html -- ./template.hbs && node generatePDF",
-    "generate-partial": "hbs -H ../helpers/eq.js -H ../helpers/not.js --data ../json/guest-requested-debtor-pdf.json -e html -- ./template.hbs && node generatePDF"
+    "generate-complete": "hbs -H ../helpers/eq.js -H ../helpers/not.js -H ../helpers/splitAndSpace.js --data ../json/authenticated-pdf.json -e html -- ./template.hbs && node generatePDF",
+    "generate-partial": "hbs -H ../helpers/eq.js -H ../helpers/not.js -H ../helpers/splitAndSpace.js --data ../json/guest-requested-debtor-pdf.json -e html -- ./template.hbs && node generatePDF"
   },
   "license": "ISC",
   "dependencies": {

--- a/receipt/success/pdf/template.hbs
+++ b/receipt/success/pdf/template.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.5">
+<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.6">
 
 <head>
   <title>Il riepilogo del tuo pagamento</title>

--- a/receipt/success/pdf/template.hbs
+++ b/receipt/success/pdf/template.hbs
@@ -171,7 +171,7 @@
                 {{#eq this.refNumber.type "codiceAvviso"}}
                 <dl class="data-key-value right-align">
                   <dt>Codice avviso</dt>
-                  <dd class="entityCode">{{this.refNumber.value}}</dd>
+                  <dd class="entityCode">{{splitAndSpace this.refNumber.value}}</dd>
                 </dl>
                 {{/eq}}
 


### PR DESCRIPTION
This PR adds the `splitAndSpace` helper to separate different number chunks in the field "Codice avviso". The helper was introduced thanks to the following PR:
* https://github.com/pagopa/pagopa-pdf-engine/pull/75

#### List of Changes
- Add the `splitAndSpace` helper to the corresponding folder
- Update template accordingly
- Bump template version