### PR TITLE
chore: Add `fullName` instead of separated name and surname

### DIFF
--- a/receipt/success/json/authenticated-apple-pay-pdf.json
+++ b/receipt/success/json/authenticated-apple-pay-pdf.json
@@ -26,8 +26,7 @@
   },
   "user": {
     "data": {
-      "firstName": "Marzia",
-      "lastName": "Roccaraso",
+      "fullName": "Marzia Roccaraso",
       "taxCode": "RCCMRZ88A52C409A"
     },
     "email": "nome.cognome@pagopa.it"

--- a/receipt/success/json/authenticated-extra-fee-pdf.json
+++ b/receipt/success/json/authenticated-extra-fee-pdf.json
@@ -26,8 +26,7 @@
   },
   "user": {
     "data": {
-      "firstName": "Marzia",
-      "lastName": "Roccaraso",
+      "fullName": "Marzia Roccaraso",
       "taxCode": "RCCMRZ88A52C409A"
     },
     "email": "nome.cognome@pagopa.it"

--- a/receipt/success/json/authenticated-multiple-cart-items-pdf.json
+++ b/receipt/success/json/authenticated-multiple-cart-items-pdf.json
@@ -27,8 +27,7 @@
   },
   "user": {
     "data": {
-      "firstName": "Marzia",
-      "lastName": "Roccaraso",
+      "fullName": "Marzia Roccaraso",
       "taxCode": "RCCMRZ88A52C409A"
     },
     "email": "nome.cognome@pagopa.it"

--- a/receipt/success/json/authenticated-pdf.json
+++ b/receipt/success/json/authenticated-pdf.json
@@ -27,8 +27,7 @@
   },
   "user": {
     "data": {
-      "firstName": "Marzia",
-      "lastName": "Roccaraso",
+      "fullName": "Marzia Roccaraso",
       "taxCode": "RCCMRZ88A52C409A"
     },
     "email": "nome.cognome@pagopa.it"

--- a/receipt/success/pdf/template.hbs
+++ b/receipt/success/pdf/template.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.7">
+<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.8">
 
 <head>
   <title>Il riepilogo del tuo pagamento</title>
@@ -24,7 +24,7 @@
           <img class="logo" src="assets/logo-pagoPa.svg" />
           <h1 class="title">Ricevuta di pagamento</h1>
         </section>
-        {{#if transaction.psp}}
+        {{#if transaction.psp.logo}}
         <dl class="psp-header">
           <dt>Emessa da</dt>
           <dd><img class="psp-logo" alt={{transaction.psp.name}} src={{transaction.psp.logo}} /></dd>
@@ -43,7 +43,7 @@
               <dl class="data-key-value">
                 <dt>Eseguito da</dt>
                 <dd class="entityGroup">
-                  <span class="entityName">{{firstName}} {{lastName}}</span>
+                  <span class="entityName">{{fullName}}</span>
                   <span class="entityCode">{{taxCode}}</span>
                 </dd>
               </dl>
@@ -207,7 +207,7 @@
             {{/not}}
 
             <!-- Commissione -->
-            {{#if transaction.psp}}
+            {{#if transaction.psp.fee}}
             <dl class="transaction-summary-key-value">
               <dt>Commissione (applicata da {{transaction.psp.name}})</dt>
               <dd>{{transaction.psp.fee.amount}}&nbsp;&euro;</dd>


### PR DESCRIPTION
This PR edits the template to use `fullName` instead of separated name and surname

#### List of Changes
- https://github.com/pagopa/pagopa-template-receipt-pdf/commit/384182373e9b8b180f4cd694b40fd4ba7bd02ebb Update JSON with fullName instead of separated name and surname 
- https://github.com/pagopa/pagopa-template-receipt-pdf/commit/589b8de5664f35801d0760e431c2f7d9a90e66aa Add fullName support to the template
- Bump template version
