### PR TITLE
chore: Add dimension limits to the PSP logo

### DIFF
--- a/receipt/success/pdf/style.css
+++ b/receipt/success/pdf/style.css
@@ -77,7 +77,7 @@ body {
   display: flex;
   height: 100%;
   flex-direction: column;
-  gap: 5mm;
+  gap: 6mm;
   background-color: white;
 }
 
@@ -126,8 +126,9 @@ body {
 }
 
 .psp-logo {
-  height: 6mm;
   width: auto;
+  max-height: 8mm;
+  max-width: 30mm;
 }
 
 main {

--- a/receipt/success/pdf/template.hbs
+++ b/receipt/success/pdf/template.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.9">
+<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.10">
 
 <head>
   <title>Il riepilogo del tuo pagamento</title>
@@ -20,7 +20,9 @@
         {{#if transaction.psp.logo}}
         <dl class="psp-header">
           <dt>Emessa da</dt>
-          <dd><img class="psp-logo" alt={{transaction.psp.name}} src={{transaction.psp.logo}} /></dd>
+          <dd style="display: inline-flex; align-self: flex-end">
+            <img class="psp-logo" alt={{transaction.psp.name}} src={{transaction.psp.logo}} />
+          </dd>
         </dl>
         {{/if}}
       </header>


### PR DESCRIPTION
This PR adds dimension limits to the PSP logo (that could exist in various sizes and ratios)

#### List of Changes
- Add `max-width` and `max-height` to the PSP logo