### PR TITLE
chore: Add disclaimer to the receipt when fee is not defined

### DIFF
--- a/receipt/success/pdf/style.css
+++ b/receipt/success/pdf/style.css
@@ -156,7 +156,7 @@ footer {
   font-size: var(--caption-fsize);
   color: var(--secondary-color);
   display: grid;
-  row-gap: 4mm;
+  row-gap: 5mm;
 }
 
 footer * {
@@ -172,6 +172,7 @@ footer * {
   display: grid;
   grid-template-columns: 6fr 4fr;
   align-content: flex-start;
+  line-height: 1.35;
 }
 
 hr {

--- a/receipt/success/pdf/template.hbs
+++ b/receipt/success/pdf/template.hbs
@@ -136,7 +136,7 @@
 
               <!-- Ente creditore (+ codice fiscale) -->
               <dl class="data-key-value small transaction-detail-creditor">
-                <dt>Ente creditore</dt>
+                <dt>Ente Creditore</dt>
                 <dd class="entityGroup">
                   <span class="entityName">{{this.payee.name}}</span>
                   <span class="entityCode">{{this.payee.taxCode}}</span>
@@ -217,10 +217,23 @@
 
       <footer>
 
-        <p>
-          Questa ricevuta attesta il pagamento eseguito. Rivolgiti all’Ente Creditore se hai bisogno della quietanza
-          liberatoria.
-        </p>
+        <div class="footer-disclaimer">
+          <p>
+            <strong>
+              Questa ricevuta attesta il pagamento eseguito. Rivolgiti all’Ente Creditore se hai bisogno della quietanza
+              liberatoria.
+            </strong>
+          </p>
+
+          {{#unless transaction.psp.fee.amount}}
+          <p>
+            Il totale non include i costi di commissione: puoi trovarli nel documento che hai ricevuto da
+            {{transaction.psp.name}}.
+          </p>
+          {{/unless}}
+
+        </div>
+
 
         <div class="company-info">
           <div class="pagopa-company-address">


### PR DESCRIPTION
This PR adds the new disclaimer to the document footer when the transaction fee is not defined.

#### List of Changes
- Add the new disclaimer to the document footer
- Fix **Ente Creditore** copy (was **Ente creditore** before)
- Improve footer style section by increasing the spacing between sections

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)