### PR TITLE
chore: Improve the size of the PSP logo

### DIFF
--- a/receipt/success/pdf/style.css
+++ b/receipt/success/pdf/style.css
@@ -126,9 +126,17 @@ body {
 }
 
 .psp-logo {
-  width: auto;
-  max-height: 8mm;
-  max-width: 30mm;
+  display: inline-flex;
+  align-self: flex-end;
+  height: 7.5mm;
+  width: 35mm;
+}
+
+.psp-logo img {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+  object-position: top right;
 }
 
 main {

--- a/receipt/success/pdf/template.hbs
+++ b/receipt/success/pdf/template.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.11">
+<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.12">
 
 <head>
   <title>Il riepilogo del tuo pagamento</title>
@@ -20,8 +20,8 @@
         {{#if transaction.psp.logo}}
         <dl class="psp-header">
           <dt>Emessa da</dt>
-          <dd style="display: inline-flex; align-self: flex-end">
-            <img class="psp-logo" alt={{transaction.psp.name}} src={{transaction.psp.logo}} />
+          <dd class="psp-logo">
+            <img alt={{transaction.psp.name}} src={{transaction.psp.logo}} />
           </dd>
         </dl>
         {{/if}}


### PR DESCRIPTION
This PR improves the size of the PSP logo (in the top right of the document)

#### List of Changes
- Improve style logic of PSP logo
- Bump template version