### PR TITLE
chore: Hide PSP logo if payment is not processed by PagoPA main services

### DIFF
--- a/receipt/success/json/authenticated-apple-pay-pdf.json
+++ b/receipt/success/json/authenticated-apple-pay-pdf.json
@@ -22,7 +22,8 @@
       "name": "Apple Pay",
       "logo": "../assets/methods/apple-pay.png",
       "extraFee": false
-    }
+    },
+    "processedByPagoPA": true
   },
   "user": {
     "data": {

--- a/receipt/success/json/authenticated-extra-fee-pdf.json
+++ b/receipt/success/json/authenticated-extra-fee-pdf.json
@@ -22,7 +22,8 @@
       "name": "Conto corrente *1234",
       "accountHolder": "Marzia Roccaraso",
       "extraFee": true
-    }
+    },
+    "processedByPagoPA": true
   },
   "user": {
     "data": {

--- a/receipt/success/json/authenticated-multiple-cart-items-pdf.json
+++ b/receipt/success/json/authenticated-multiple-cart-items-pdf.json
@@ -23,7 +23,8 @@
       "logo": "../assets/methods/unionpay.png",
       "accountHolder": "Marzia Roccaraso",
       "extraFee": false
-    }
+    },
+    "processedByPagoPA": true
   },
   "user": {
     "data": {

--- a/receipt/success/json/authenticated-pdf.json
+++ b/receipt/success/json/authenticated-pdf.json
@@ -24,7 +24,7 @@
       "accountHolder": "Marzia Roccaraso",
       "extraFee": false
     },
-    "processedByPagoPA": false
+    "processedByPagoPA": true
   },
   "user": {
     "data": {

--- a/receipt/success/json/authenticated-pdf.json
+++ b/receipt/success/json/authenticated-pdf.json
@@ -23,7 +23,8 @@
       "logo": "assets/mastercard.png",
       "accountHolder": "Marzia Roccaraso",
       "extraFee": false
-    }
+    },
+    "processedByPagoPA": false
   },
   "user": {
     "data": {

--- a/receipt/success/json/guest-multiple-cart-items-requested-debtor-pdf.json
+++ b/receipt/success/json/guest-multiple-cart-items-requested-debtor-pdf.json
@@ -16,6 +16,7 @@
         "amount": "2,00"
       }
     },
+    "processedByPagoPA": true,
     "requestedByDebtor": true
   },
   "cart": {

--- a/receipt/success/json/guest-requested-debtor-pdf.json
+++ b/receipt/success/json/guest-requested-debtor-pdf.json
@@ -16,6 +16,7 @@
         "amount": "2,00"
       }
     },
+    "processedByPagoPA": true,
     "requestedByDebtor": true
   },
   "cart": {

--- a/receipt/success/pdf/template.hbs
+++ b/receipt/success/pdf/template.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.14">
+<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.15">
 
 <head>
   <title>Il riepilogo del tuo pagamento</title>
@@ -17,6 +17,7 @@
           <img class="logo" src="assets/logo-pagoPa.svg" />
           <h1 class="title">Ricevuta di pagamento</h1>
         </section>
+        {{#if transaction.processedByPagoPA}}
         {{#if transaction.psp.logo}}
         <dl class="psp-header">
           <dt>Emessa da</dt>
@@ -24,6 +25,7 @@
             <img alt={{transaction.psp.name}} src={{transaction.psp.logo}} />
           </dd>
         </dl>
+        {{/if}}
         {{/if}}
       </header>
 


### PR DESCRIPTION
This PR hides the PSP logo if the payment is not processed by PagoPA main services.

#### List of Changes
- Add the new `processedByPagoPA` boolean value in the mocked JSON file
- Update template with the relative condition
- Bump template version