### PR TITLE
chore: First template update after business simulation (CapitalCase full names, more checks to see if data exists)

### DIFF
--- a/receipt/success/helpers/lowercase.js
+++ b/receipt/success/helpers/lowercase.js
@@ -1,0 +1,9 @@
+var lowercase = function () {};
+
+lowercase.register = function (Handlebars) {
+  Handlebars.registerHelper("lowercase", function (str) {
+    return str.toLowerCase();
+  });
+};
+
+module.exports = lowercase;

--- a/receipt/success/json/authenticated-pdf.json
+++ b/receipt/success/json/authenticated-pdf.json
@@ -19,16 +19,16 @@
     "rrn": "1234567890",
     "authCode": "1234567890123456800",
     "paymentMethod": {
-      "name": "Carta Mastercard",
+      "name": "MASTERCARD",
       "logo": "assets/mastercard.png",
-      "accountHolder": "Marzia Roccaraso",
+      "accountHolder": "MARZIA ROCCARASO",
       "extraFee": false
     },
     "processedByPagoPA": true
   },
   "user": {
     "data": {
-      "fullName": "Marzia Roccaraso",
+      "fullName": "MARZIA ROCCARASO",
       "taxCode": "RCCMRZ88A52C409A"
     },
     "email": "nome.cognome@pagopa.it"

--- a/receipt/success/pdf/package.json
+++ b/receipt/success/pdf/package.json
@@ -4,8 +4,8 @@
   "description": "Template used to generate pagoPA PDF receipts",
   "main": "index.js",
   "scripts": {
-    "generate-complete": "hbs -H ../helpers/eq.js -H ../helpers/not.js -H ../helpers/splitAndSpace.js --data ../json/authenticated-pdf.json -e html -- ./template.hbs && node generatePDF",
-    "generate-partial": "hbs -H ../helpers/eq.js -H ../helpers/not.js -H ../helpers/splitAndSpace.js --data ../json/guest-requested-debtor-pdf.json -e html -- ./template.hbs && node generatePDF"
+    "generate-complete": "hbs -H ../helpers/eq.js -H ../helpers/not.js -H ../helpers/splitAndSpace.js -H ../helpers/lowercase.js --data ../json/authenticated-pdf.json -e html -- ./template.hbs && node generatePDF",
+    "generate-partial": "hbs -H ../helpers/eq.js -H ../helpers/not.js -H ../helpers/splitAndSpace.js -H ../helpers/lowercase.js --data ../json/guest-requested-debtor-pdf.json -e html -- ./template.hbs && node generatePDF"
   },
   "license": "ISC",
   "dependencies": {

--- a/receipt/success/pdf/style.css
+++ b/receipt/success/pdf/style.css
@@ -336,6 +336,10 @@ hr {
   margin-top: 0.1em;
 }
 
+.forcedCapitalCase {
+  text-transform: capitalize;
+}
+
 .payment-method-group {
   display: flex;
   align-items: center;

--- a/receipt/success/pdf/template.hbs
+++ b/receipt/success/pdf/template.hbs
@@ -239,7 +239,7 @@
             <p><strong>Ricevuta trasmessa da PagoPA S.p.A.</strong></p>
             <p>
               Piazza Colonna, 370<br />
-              00187, Roma
+              00187 Roma (RM)
             </p>
           </div>
 
@@ -249,7 +249,7 @@
             <p><strong>Pagamento gestito da {{transaction.psp.companyName}}</strong></p>
             <p>
               {{transaction.psp.address}}, {{transaction.psp.buildingNumber}}<br />
-              {{transaction.psp.postalCode}}, {{transaction.psp.city}} ({{transaction.psp.province}})
+              {{transaction.psp.postalCode}} {{transaction.psp.city}} ({{transaction.psp.province}})
             </p>
           </div>
           {{/if}}

--- a/receipt/success/pdf/template.hbs
+++ b/receipt/success/pdf/template.hbs
@@ -125,7 +125,9 @@
               <dl class="data-key-value small transaction-detail-debtor">
                 <dt>Debitore</dt>
                 <dd class="entityGroup">
+                  {{#if fullName}}
                   <span class="entityName">{{fullName}}</span>
+                  {{/if}}
                   {{#if taxCode}}
                   <span class="entityCode">{{taxCode}}</span>
                   {{/if}}

--- a/receipt/success/pdf/template.hbs
+++ b/receipt/success/pdf/template.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.16">
+<html lang="it" xmlns="http://www.w3.org/1999/xhtml" version="0.0.17">
 
 <head>
   <title>Il riepilogo del tuo pagamento</title>
@@ -40,7 +40,9 @@
               <dl class="data-key-value">
                 <dt>Eseguito da</dt>
                 <dd class="entityGroup">
-                  <span class="entityName">{{fullName}}</span>
+                  {{#if fullName}}
+                  <span class="entityName forcedCapitalCase">{{lowercase fullName}}</span>
+                  {{/if}}
                   <span class="entityCode">{{taxCode}}</span>
                 </dd>
               </dl>
@@ -70,9 +72,9 @@
               <dl class="data-key-value">
                 <dt>Metodo di pagamento</dt>
                 <dd class="data-value-big">
-                  <div class="payment-method-group">
+                  <div class="payment-method-group forcedCapitalCase">
                     <img class="payment-method-logo" src={{transaction.paymentMethod.logo}} />
-                    {{transaction.paymentMethod.name}}
+                    {{lowercase transaction.paymentMethod.name}}
                   </div>
                 </dd>
               </dl>
@@ -81,7 +83,7 @@
               {{#if transaction.paymentMethod.accountHolder}}
               <dl class="data-key-value">
                 <dt>Intestato a</dt>
-                <dd class="data-value-big">{{transaction.paymentMethod.accountHolder}}</dd>
+                <dd class="data-value-big forcedCapitalCase">{{lowercase transaction.paymentMethod.accountHolder}}</dd>
               </dl>
               {{/if}}
 


### PR DESCRIPTION
This PR updates the template after the first run of the internal business simulation.

#### List of Changes
- [Completely hide `fullName` if not set](https://github.com/pagopa/pagopa-template-receipt-pdf/commit/c74ad7806f24e9739584fcc352413a3a69480ad1)
- [Force CapitalCase on `fullName` and `paymentMethod` fields](https://github.com/pagopa/pagopa-template-receipt-pdf/commit/7f867a0ddbf1e64d58b73a7ba49f19a29d7cf14b)
- [Improve formatting of the PagoPA and PSP addresses](https://github.com/pagopa/pagopa-template-receipt-pdf/commit/13226a69e54e98637f8d630c4555817c6bb3ba07)
- Bump template version